### PR TITLE
DO-3352 - Use awscli image that does not have env variables for aws access keys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Tag: vungle/geoipupdate
-FROM vungle/awscli
-MAINTAINER Steve Jiang <steve.jiang@vungle.com>
+FROM vungle/awscli:1.17
 
 COPY files/geoipupdate /usr/local/bin/geoipupdate
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# v0.3.3
+
+Using awscli Docker image 1.17 that does not declare environment variables for AWS access keys in order to avoid any conflict with the service account annotation when assuming IAM role. AWS access keys env variables are declared within the application's helm chart.
+
 # Maxmind Geo IP update Docker image
 
 The GeoIPUpdate container is designed to be run within a Kubernetes pod with the


### PR DESCRIPTION
For the pod assuming role feature, we need to remove the declaration of AWS access keys within the docker image.